### PR TITLE
Update to Spree 1.0.3

### DIFF
--- a/app/controllers/admin/google_merchants_controller.rb
+++ b/app/controllers/admin/google_merchants_controller.rb
@@ -1,4 +1,4 @@
-class Admin::GoogleMerchantsController < Admin::BaseController
+class Admin::GoogleMerchantsController < Spree::Admin::BaseController
 
   def update
     Spree::GoogleMerchant::Config.set(params[:preferences])

--- a/app/controllers/products_decorator.rb
+++ b/app/controllers/products_decorator.rb
@@ -1,4 +1,4 @@
-ProductsController.class_eval do
+Spree::ProductsController.class_eval do
   def google_merchant
     @products = Product.active
   end

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -10,7 +10,7 @@ namespace :spree_google_merchant do
     task :migrations do
       source = File.join(File.dirname(__FILE__), '..', '..', 'db')
       destination = File.join(Rails.root, 'db')
-      Spree::FileUtilz.mirror_files(source, destination)
+      Spree::Core::FileUtilz.mirror_files(source, destination)
     end
 
     desc "Copies all assets (NOTE: This will be obsolete with Rails 3.1)"
@@ -18,7 +18,7 @@ namespace :spree_google_merchant do
       source = File.join(File.dirname(__FILE__), '..', '..', 'public')
       destination = File.join(Rails.root, 'public')
       puts "INFO: Mirroring assets from #{source} to #{destination}"
-      Spree::FileUtilz.mirror_files(source, destination)
+      Spree::Core::FileUtilz.mirror_files(source, destination)
     end
   end
 


### PR DESCRIPTION
So far, I had just to adjust package names and prefix former Spree-Models with "Spree::"
